### PR TITLE
Add Quarto glossary scaffold for agentic workflow terms (docs/learning)

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,3 @@
+/.quarto/
+**/*.quarto_ipynb
+/_site/

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -1,0 +1,35 @@
+project:
+  type: website
+  output-dir: _site
+
+website:
+  title: "Agentic Workflows in PMx"
+  page-navigation: true
+
+  navbar:
+    background: light
+    left:
+      - text: "Glossary"
+        href: learning/glossary/agent.qmd
+
+  sidebar:
+    - id: glossary
+      title: "Glossary"
+      style: floating
+      collapse-level: 2
+      search: true
+      contents:
+        - text: "Agent"
+          href: learning/glossary/agent.qmd
+        - text: "Harness"
+          href: learning/glossary/harness.qmd
+        - text: "MCP (Model Context Protocol)"
+          href: learning/glossary/mcp.qmd
+        - text: "Tools"
+          href: learning/glossary/tools.qmd
+
+format:
+  html:
+    theme: cosmo
+    toc: true
+    toc-title: "On this page"

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -1,0 +1,12 @@
+---
+title: "Agentic Workflows in Pharmacometrics"
+sidebar: false
+---
+
+Community resources from the AIML-SIG on agentic workflows in pharmacometrics.
+
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.  
+
+Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat.  
+
+Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat. Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi.  

--- a/docs/learning/glossary/agent.qmd
+++ b/docs/learning/glossary/agent.qmd
@@ -1,0 +1,33 @@
+---
+title: "Agent"
+date: 2026-07-02
+date-modified: 2026-07-02
+---
+
+::: {style="font-size: 0.8em; color: #888;"}
+Contributors: Jane Doe, Ali Khan, Maria Smith (replace)
+:::
+
+> One-sentence plain-language summary of the term.
+
+## Definition
+
+A short definition for a pharmacometrics audience. If another glossary term is needed (such as [Harness](harness.qmd)), link to it. Beyond the definition itself, already briefly explain why the concept matters. An analogy or a simplified breakdown (bullets) can help. 
+
+## In pharmacometrics
+
+Briefly explain why this concept is relevant to pharmacometric workflows, such as model development, dataset preparation, NONMEM/R/Python code, quality control, benchmarking, reproducibility, traceability, or human review.
+
+Concrete examples follow as subsections, each with a descriptive heading prefixed with "Example:".
+
+### Example: Descriptive heading 1
+
+A concrete example of the term in a pharmacometrics context, ideally with code snippets or diagrams where they clarify the mechanics.
+
+## Related terms
+
+[Harness](harness.qmd) · [MCP](mcp.qmd)
+
+## Further reading
+
+- Optional: links to docs, papers, blog posts. Curated, not exhaustive.

--- a/docs/learning/glossary/harness.qmd
+++ b/docs/learning/glossary/harness.qmd
@@ -1,0 +1,33 @@
+---
+title: "Harness"
+date: 2026-07-02
+date-modified: 2026-07-02
+---
+
+::: {style="font-size: 0.8em; color: #888;"}
+Contributors: Jane Doe, Ali Khan, Maria Smith (replace)
+:::
+
+> One-sentence plain-language summary of the term.
+
+## Definition
+
+A short definition for a pharmacometrics audience. If another glossary term is needed (such as [Harness](harness.qmd)), link to it. Beyond the definition itself, already briefly explain why the concept matters. An analogy or a simplified breakdown (bullets) can help. 
+
+## In pharmacometrics
+
+Briefly explain why this concept is relevant to pharmacometric workflows, such as model development, dataset preparation, NONMEM/R/Python code, quality control, benchmarking, reproducibility, traceability, or human review.
+
+Concrete examples follow as subsections, each with a descriptive heading prefixed with "Example:".
+
+### Example: Descriptive heading 1
+
+A concrete example of the term in a pharmacometrics context, ideally with code snippets or diagrams where they clarify the mechanics.
+
+## Related terms
+
+[Harness](harness.qmd) · [MCP](mcp.qmd)
+
+## Further reading
+
+- Optional: links to docs, papers, blog posts. Curated, not exhaustive.

--- a/docs/learning/glossary/mcp.qmd
+++ b/docs/learning/glossary/mcp.qmd
@@ -1,0 +1,127 @@
+---
+title: "MCP (Model Context Protocol)"
+date: 2026-07-02
+date-modified: 2026-07-02
+---
+
+::: {style="font-size: 0.8em; color: #888;"}
+Contributors: Marian Klose
+:::
+
+> An open standard that lets an AI application talk to external tools and data through one common interface instead of a separate custom integration for each.
+
+## Definition
+
+The Model Context Protocol (MCP) is an open protocol, introduced by Anthropic in late 2024 and now maintained as a community specification, that standardizes how large language model (LLM) applications connect to external [tools](tools.qmd) and data sources. Similar to how USB-C replaces the need for many different cables with one shared standard for connecting devices, MCP provides a common protocol that lets AI applications connect to external systems.
+
+Concretely, MCP sets the rules for how an LLM application (e.g., Claude, ChatGPT) and a server talk to each other when using a tool. The exchanges break down into four parts (simplified):
+
+- **Tool discovery**: The AI application asks: *Which tools do you have?*
+- **Tool description**: The MCP server answers: *Here is each tool, what it does, and which inputs it needs.*
+- **Tool invocation**: The AI application says: *Run this tool with these arguments.*
+- **Tool result**: The MCP server sends the result back in a structured, predictable form after the tool is executed.
+
+Because MCP servers follow the same protocol, MCP-compatible applications can integrate with new tools without writing a custom connector for each one.
+
+![MCP overview. Inspired by [modelcontextprotocol.io](https://modelcontextprotocol.io/docs/getting-started/intro)](media/mcp/mcp-overview.svg)
+
+## In pharmacometrics
+
+[Tools](tools.qmd) are key for agentic workflows in pharmacometrics, because the LLM itself cannot run NONMEM or R code, nor can it access the datasets and model files that are needed to do so. An MCP server allows a team to wrap these tools and expose them to the LLM in a uniform way, so that the LLM can be used to automate tasks like running NONMEM models or generating exploratory data analysis plots. 
+
+
+### Example: MCP server exposing a NONMEM run
+
+A pharmacometrics team wraps their NONMEM execution environment in an MCP server that exposes a small set of tools: 
+
+- `submit_run` (takes a control stream and executes the run)
+- `get_run_status` (returns the current status of a run, e.g., pending, running, minimization successful, terminated, etc.)
+- `get_results` (returns objective function value). 
+
+When an LLM [harness](harness.qmd) is connected to this MCP server, it would first check which tools are available. The harness sends a `tools/list` request to the server:
+
+```json
+{ "jsonrpc": "2.0", "id": 1, "method": "tools/list" }
+```
+
+The server responds with a machine-readable description of every tool it offers: its name, what it does, and a schema for its inputs:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "tools": [
+      {
+        "name": "submit_run",
+        "description": "Launch a NONMEM estimation for a given control stream.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "control_stream": {
+              "type": "string",
+              "description": "Path to the .mod / .ctl file"
+            }
+          },
+          "required": [
+            "control_stream"
+          ]
+        }
+      },
+      {
+        "name": "get_run_status",
+        "description": "Return the current status of a run",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "run_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "run_id"
+          ]
+        }
+      },
+      {
+        "name": "get_results",
+        "description": "Return the objective function value of a completed run.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "run_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "run_id"
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+
+The harness converts these definitions into the tool-calling format of its LLM API and includes them in the model's context. From that point on, the model can decide on its own to call, say, `submit_run` with a control stream.
+
+
+If a user then asks the LLM to "run `run042.mod` in NONMEM and give back the OFV", the LLM can reason that it needs to call `submit_run` with the control stream, then poll `get_run_status` until the run is complete, and finally call `get_results` to retrieve the objective function value. The LLM can then return this value to the user:
+
+> The objective function value for `run042.mod` is 1234.56.
+
+The interaction is visualized in the following diagram:
+
+![MCP tool use diagram](media/mcp/mcp-tool-use-diagram.svg)
+
+In a properly configured implementation, each action can be logged as a JSON-RPC request/response, making the run traceable.
+
+## Related terms
+
+[Tools](tools.qmd)
+
+## Further reading
+
+- [Model Context Protocol specification](https://modelcontextprotocol.io): the authoritative spec and SDKs.
+- [Introducing the Model Context Protocol](https://www.anthropic.com/news/model-context-protocol): the original announcement and motivation.
+

--- a/docs/learning/glossary/media/mcp/mcp-overview.svg
+++ b/docs/learning/glossary/media/mcp/mcp-overview.svg
@@ -1,0 +1,84 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 420" font-family="Helvetica Neue, Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="ah2" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 z" fill="#64748B"/>
+    </marker>
+  </defs>
+  <style>
+    .flow { stroke: #94A3B8; stroke-width: 1.6; fill: none; }
+    .lbl { font-size: 11.5px; fill: #0F172A; text-anchor: middle; font-weight: 600; }
+    .iconL { stroke: #1E40AF; stroke-width: 1.8; fill: none; stroke-linecap: round; stroke-linejoin: round; }
+    .iconR { stroke: #166534; stroke-width: 1.8; fill: none; stroke-linecap: round; stroke-linejoin: round; }
+  </style>
+
+  <rect x="0" y="0" width="900" height="420" fill="#ffffff"/>
+
+  <!-- ============ LEFT: AI APPLICATIONS ============ -->
+  <!-- chat interfaces -->
+  <rect x="116" y="78" width="48" height="48" rx="12" fill="#EFF6FF" stroke="#93C5FD" stroke-width="1.5"/>
+  <rect x="127" y="91" width="26" height="18" rx="5" class="iconL"/>
+  <path d="M132 109 l-3 7 l9 -7" class="iconL"/>
+  <circle cx="134" cy="100" r="1.4" fill="#1E40AF" stroke="none"/>
+  <circle cx="140" cy="100" r="1.4" fill="#1E40AF" stroke="none"/>
+  <circle cx="146" cy="100" r="1.4" fill="#1E40AF" stroke="none"/>
+  <text x="140" y="144" class="lbl">Chat interfaces</text>
+
+  <!-- IDEs & code editors -->
+  <rect x="116" y="178" width="48" height="48" rx="12" fill="#EFF6FF" stroke="#93C5FD" stroke-width="1.5"/>
+  <path d="M134 194 L126 202 L134 210" class="iconL"/>
+  <path d="M146 194 L154 202 L146 210" class="iconL"/>
+  <line x1="142.5" y1="193" x2="137.5" y2="211" class="iconL"/>
+  <text x="140" y="244" class="lbl">IDEs &amp; code editors</text>
+
+  <!-- agents -->
+  <rect x="116" y="278" width="48" height="48" rx="12" fill="#EFF6FF" stroke="#93C5FD" stroke-width="1.5"/>
+  <rect x="128" y="298" width="24" height="16" rx="5" class="iconL"/>
+  <circle cx="135" cy="306" r="1.8" fill="#1E40AF" stroke="none"/>
+  <circle cx="145" cy="306" r="1.8" fill="#1E40AF" stroke="none"/>
+  <line x1="140" y1="298" x2="140" y2="292" class="iconL"/>
+  <circle cx="140" cy="289.5" r="2.2" class="iconL"/>
+  <text x="140" y="344" class="lbl">Agents &amp; automations</text>
+
+  <text x="140" y="402" font-size="11" font-weight="600" fill="#1E40AF" text-anchor="middle" letter-spacing="0.5">AI APPLICATIONS</text>
+
+  <!-- ============ CENTER: MCP ============ -->
+  <rect x="360" y="150" width="180" height="120" rx="14" fill="#DBEAFE" stroke="#3B82F6" stroke-width="1.6"/>
+  <text x="450" y="205" font-size="21" font-weight="700" fill="#1E3A8A" text-anchor="middle">MCP</text>
+  <text x="450" y="227" font-size="11" fill="#334155" text-anchor="middle">one standardized protocol</text>
+  <text x="450" y="294" font-size="10" font-style="italic" fill="#94A3B8" text-anchor="middle">any AI application &#8596; any tool or data server</text>
+
+  <!-- ============ CONNECTIONS ============ -->
+  <path d="M172 102 C 255 102, 275 175, 356 175" class="flow" marker-start="url(#ah2)" marker-end="url(#ah2)"/>
+  <path d="M172 202 C 255 202, 275 210, 356 210" class="flow" marker-start="url(#ah2)" marker-end="url(#ah2)"/>
+  <path d="M172 302 C 255 302, 275 245, 356 245" class="flow" marker-start="url(#ah2)" marker-end="url(#ah2)"/>
+
+  <path d="M728 102 C 645 102, 625 175, 544 175" class="flow" marker-start="url(#ah2)" marker-end="url(#ah2)"/>
+  <path d="M728 202 C 645 202, 625 210, 544 210" class="flow" marker-start="url(#ah2)" marker-end="url(#ah2)"/>
+  <path d="M728 302 C 645 302, 625 245, 544 245" class="flow" marker-start="url(#ah2)" marker-end="url(#ah2)"/>
+
+  <!-- ============ RIGHT: TOOLS & DATA ============ -->
+  <!-- databases & files -->
+  <rect x="736" y="78" width="48" height="48" rx="12" fill="#F0FDF4" stroke="#86EFAC" stroke-width="1.5"/>
+  <ellipse cx="760" cy="93" rx="12" ry="4.5" class="iconR"/>
+  <path d="M748 93 L748 111 A 12 4.5 0 0 0 772 111 L772 93" class="iconR"/>
+  <path d="M748 102 A 12 4.5 0 0 0 772 102" class="iconR"/>
+  <text x="760" y="144" class="lbl">Databases &amp; files</text>
+
+  <!-- developer tools (git branch) -->
+  <rect x="736" y="178" width="48" height="48" rx="12" fill="#F0FDF4" stroke="#86EFAC" stroke-width="1.5"/>
+  <circle cx="753" cy="192" r="3.2" class="iconR"/>
+  <circle cx="753" cy="212" r="3.2" class="iconR"/>
+  <circle cx="768" cy="192" r="3.2" class="iconR"/>
+  <line x1="753" y1="195.2" x2="753" y2="208.8" class="iconR"/>
+  <path d="M768 195.2 C 768 203, 753 200, 753 206" class="iconR"/>
+  <text x="760" y="244" class="lbl">Developer tools</text>
+
+  <!-- web services & APIs (globe) -->
+  <rect x="736" y="278" width="48" height="48" rx="12" fill="#F0FDF4" stroke="#86EFAC" stroke-width="1.5"/>
+  <circle cx="760" cy="302" r="11" class="iconR"/>
+  <ellipse cx="760" cy="302" rx="5" ry="11" class="iconR"/>
+  <line x1="749" y1="302" x2="771" y2="302" class="iconR"/>
+  <text x="760" y="344" class="lbl">Web services &amp; APIs</text>
+
+  <text x="760" y="402" font-size="11" font-weight="600" fill="#166534" text-anchor="middle" letter-spacing="0.5">TOOLS &amp; DATA SOURCES</text>
+</svg>

--- a/docs/learning/glossary/media/mcp/mcp-tool-use-diagram.svg
+++ b/docs/learning/glossary/media/mcp/mcp-tool-use-diagram.svg
@@ -1,0 +1,122 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 505" font-family="Helvetica Neue, Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="ah" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 z" fill="#475569"/>
+    </marker>
+  </defs>
+  <style>
+    .mono { font-family: "SF Mono", Consolas, Menlo, monospace; }
+    .arrow { stroke: #475569; stroke-width: 1.6; fill: none; }
+    .badge { fill: #ffffff; stroke: #475569; stroke-width: 1.3; }
+    .badgeNum { font-size: 10px; font-weight: 700; fill: #334155; text-anchor: middle; }
+  </style>
+
+  <!-- background -->
+  <rect x="0" y="0" width="960" height="505" fill="#ffffff"/>
+
+  <!-- title -->
+  <text x="30" y="36" font-size="16" font-weight="600" fill="#0F172A">Tool use via the Model Context Protocol (MCP)</text>
+  <text x="30" y="56" font-size="11.5" fill="#64748B">NONMEM example — circled numbers give the order of interactions</text>
+
+  <!-- ===================== USER ===================== -->
+  <rect x="25" y="200" width="110" height="90" rx="10" fill="#F8FAFC" stroke="#94A3B8" stroke-width="1.5"/>
+  <circle cx="80" cy="229" r="9" fill="none" stroke="#475569" stroke-width="1.6"/>
+  <path d="M62 264 C62 250 70 244 80 244 C90 244 98 250 98 264" fill="none" stroke="#475569" stroke-width="1.6"/>
+  <text x="80" y="281" font-size="12.5" font-weight="600" fill="#0F172A" text-anchor="middle">User</text>
+
+  <!-- ===================== LLM APPLICATION (HOST) ===================== -->
+  <rect x="215" y="110" width="230" height="305" rx="12" fill="#EFF6FF" stroke="#93C5FD" stroke-width="1.5"/>
+  <text x="330" y="133" font-size="13" font-weight="600" fill="#1E40AF" text-anchor="middle">LLM application (host)</text>
+
+  <!-- LLM box -->
+  <rect x="235" y="150" width="190" height="70" rx="8" fill="#ffffff" stroke="#60A5FA" stroke-width="1.4"/>
+  <text x="330" y="181" font-size="14" font-weight="600" fill="#0F172A" text-anchor="middle">LLM</text>
+  <text x="330" y="200" font-size="10.5" fill="#64748B" text-anchor="middle">(any model / provider)</text>
+
+  <!-- internal exchange LLM <-> client -->
+  <line x1="268" y1="226" x2="268" y2="252" class="arrow" marker-start="url(#ah)" marker-end="url(#ah)"/>
+  <text x="282" y="235" font-size="10" fill="#475569">&#8593; tool definitions &amp; results</text>
+  <text x="282" y="249" font-size="10" fill="#475569">&#8595; tool calls</text>
+
+  <!-- MCP client / harness box -->
+  <rect x="235" y="258" width="190" height="135" rx="8" fill="#ffffff" stroke="#60A5FA" stroke-width="1.4"/>
+  <text x="330" y="282" font-size="12.5" font-weight="600" fill="#0F172A" text-anchor="middle">MCP client / harness</text>
+  <text x="330" y="303" font-size="10" fill="#64748B" text-anchor="middle">speaks MCP with the server,</text>
+  <text x="330" y="317" font-size="10" fill="#64748B" text-anchor="middle">exposes its tools to the LLM</text>
+  <text x="330" y="337" font-size="10" font-style="italic" fill="#94A3B8" text-anchor="middle">(model-agnostic)</text>
+
+  <!-- ===================== USER <-> APPLICATION ARROWS ===================== -->
+  <text x="175" y="220" font-size="10.5" fill="#475569" text-anchor="middle">request</text>
+  <line x1="135" y1="232" x2="215" y2="232" class="arrow" marker-end="url(#ah)"/>
+  <circle cx="175" cy="232" r="8" class="badge"/>
+  <text x="175" y="235.5" class="badgeNum">1</text>
+
+  <line x1="215" y1="272" x2="135" y2="272" class="arrow" marker-end="url(#ah)"/>
+  <circle cx="175" cy="272" r="8" class="badge"/>
+  <text x="175" y="275.5" class="badgeNum">7</text>
+  <text x="175" y="292" font-size="10.5" fill="#475569" text-anchor="middle">answer</text>
+
+  <!-- ===================== CLIENT <-> SERVER ARROWS ===================== -->
+  <text x="535" y="181" font-size="10" font-style="italic" fill="#94A3B8" text-anchor="middle">JSON-RPC</text>
+  <text x="535" y="194" font-size="10" font-style="italic" fill="#94A3B8" text-anchor="middle">over stdio / HTTP</text>
+
+  <!-- 2: tools/list -->
+  <text x="535" y="258" font-size="11" fill="#0F172A" text-anchor="middle" class="mono">tools/list</text>
+  <line x1="445" y1="270" x2="625" y2="270" class="arrow" marker-end="url(#ah)"/>
+  <circle cx="535" cy="270" r="8" class="badge"/>
+  <text x="535" y="273.5" class="badgeNum">2</text>
+
+  <!-- 3: tool definitions -->
+  <text x="535" y="293" font-size="11" fill="#0F172A" text-anchor="middle">tool definitions</text>
+  <line x1="625" y1="305" x2="445" y2="305" class="arrow" marker-end="url(#ah)"/>
+  <circle cx="535" cy="305" r="8" class="badge"/>
+  <text x="535" y="308.5" class="badgeNum">3</text>
+  <text x="535" y="322" font-size="9.5" fill="#64748B" text-anchor="middle">name &#183; description &#183; input schema</text>
+
+  <!-- 4: tools/call -->
+  <text x="535" y="334" font-size="10.5" fill="#0F172A" text-anchor="middle" class="mono">tools/call (submit_run)</text>
+  <line x1="445" y1="346" x2="625" y2="346" class="arrow" marker-end="url(#ah)"/>
+  <circle cx="535" cy="346" r="8" class="badge"/>
+  <text x="535" y="349.5" class="badgeNum">4</text>
+  <text x="535" y="363" font-size="9.5" fill="#64748B" text-anchor="middle" class="mono">{ control_stream, dataset }</text>
+
+  <!-- 6: result -->
+  <text x="535" y="377" font-size="11" fill="#0F172A" text-anchor="middle">structured result</text>
+  <line x1="625" y1="389" x2="445" y2="389" class="arrow" marker-end="url(#ah)"/>
+  <circle cx="535" cy="389" r="8" class="badge"/>
+  <text x="535" y="392.5" class="badgeNum">6</text>
+  <text x="535" y="406" font-size="9.5" fill="#64748B" text-anchor="middle" class="mono">OFV = 1234.56</text>
+
+  <!-- ===================== MCP SERVER ===================== -->
+  <rect x="625" y="110" width="305" height="360" rx="12" fill="#F0FDF4" stroke="#86EFAC" stroke-width="1.5"/>
+  <text x="777" y="133" font-size="13" font-weight="600" fill="#166534" text-anchor="middle">MCP server</text>
+
+  <!-- tool interface -->
+  <rect x="643" y="150" width="269" height="212" rx="8" fill="#ffffff" stroke="#4ADE80" stroke-width="1.4"/>
+  <text x="660" y="174" font-size="12.5" font-weight="600" fill="#0F172A">Tool interface</text>
+
+  <text x="660" y="201" font-size="11.5" fill="#0F172A" class="mono">submit_run</text>
+  <text x="660" y="215" font-size="10" fill="#64748B">launch a NONMEM estimation</text>
+
+  <text x="660" y="241" font-size="11.5" fill="#0F172A" class="mono">get_run_status</text>
+  <text x="660" y="255" font-size="10" fill="#64748B">pending &#183; running &#183; completed</text>
+
+  <text x="660" y="281" font-size="11.5" fill="#0F172A" class="mono">get_results</text>
+  <text x="660" y="295" font-size="10" fill="#64748B">objective function value of a run</text>
+
+  <text x="660" y="331" font-size="9.5" font-style="italic" fill="#94A3B8">each advertised with a description and input schema</text>
+
+  <!-- 5: internal execution -->
+  <line x1="735" y1="362" x2="735" y2="400" class="arrow" marker-start="url(#ah)" marker-end="url(#ah)"/>
+  <circle cx="735" cy="381" r="8" class="badge"/>
+  <text x="735" y="384.5" class="badgeNum">5</text>
+  <text x="752" y="385" font-size="10" fill="#475569">execute &amp; collect results</text>
+
+  <!-- execution environment -->
+  <rect x="643" y="400" width="269" height="55" rx="8" fill="#F8FAFC" stroke="#94A3B8" stroke-width="1.4"/>
+  <text x="777" y="423" font-size="12" font-weight="600" fill="#0F172A" text-anchor="middle">NONMEM execution environment</text>
+  <text x="777" y="440" font-size="9.5" fill="#64748B" text-anchor="middle">runs estimations on sanctioned datasets</text>
+
+  <!-- caption -->
+  <text x="480" y="494" font-size="10.5" fill="#64748B" text-anchor="middle">Steps 2&#8211;3 (discovery &amp; description) happen in a single exchange when the client connects &#8212; steps 4&#8211;6 repeat for every tool call.</text>
+</svg>

--- a/docs/learning/glossary/template.qmd
+++ b/docs/learning/glossary/template.qmd
@@ -1,0 +1,33 @@
+---
+title: "Term Name"
+date: 2026-07-02
+date-modified: 2026-07-02
+---
+
+::: {style="font-size: 0.8em; color: #888;"}
+Contributors: Jane Doe, Ali Khan, Maria Smith (replace)
+:::
+
+> One-sentence plain-language summary of the term.
+
+## Definition
+
+A short definition for a pharmacometrics audience. If another glossary term is needed (such as [Harness](harness.qmd)), link to it. Beyond the definition itself, already briefly explain why the concept matters. An analogy or a simplified breakdown (bullets) can help. 
+
+## In pharmacometrics
+
+Briefly explain why this concept is relevant to pharmacometric workflows, such as model development, dataset preparation, NONMEM/R/Python code, quality control, benchmarking, reproducibility, traceability, or human review.
+
+Concrete examples follow as subsections, each with a descriptive heading prefixed with "Example:".
+
+### Example: Descriptive heading 1
+
+A concrete example of the term in a pharmacometrics context, ideally with code snippets or diagrams where they clarify the mechanics.
+
+## Related terms
+
+[Harness](harness.qmd) · [MCP](mcp.qmd)
+
+## Further reading
+
+- Optional: links to docs, papers, blog posts. Curated, not exhaustive.

--- a/docs/learning/glossary/tools.qmd
+++ b/docs/learning/glossary/tools.qmd
@@ -1,0 +1,33 @@
+---
+title: "Tools"
+date: 2026-07-02
+date-modified: 2026-07-02
+---
+
+::: {style="font-size: 0.8em; color: #888;"}
+Contributors: Jane Doe, Ali Khan, Maria Smith (replace)
+:::
+
+> One-sentence plain-language summary of the term.
+
+## Definition
+
+A short definition for a pharmacometrics audience. If another glossary term is needed (such as [Harness](harness.qmd)), link to it. Beyond the definition itself, already briefly explain why the concept matters. An analogy or a simplified breakdown (bullets) can help. 
+
+## In pharmacometrics
+
+Briefly explain why this concept is relevant to pharmacometric workflows, such as model development, dataset preparation, NONMEM/R/Python code, quality control, benchmarking, reproducibility, traceability, or human review.
+
+Concrete examples follow as subsections, each with a descriptive heading prefixed with "Example:".
+
+### Example: Descriptive heading 1
+
+A concrete example of the term in a pharmacometrics context, ideally with code snippets or diagrams where they clarify the mechanics.
+
+## Related terms
+
+[Harness](harness.qmd) · [MCP](mcp.qmd)
+
+## Further reading
+
+- Optional: links to docs, papers, blog posts. Curated, not exhaustive.


### PR DESCRIPTION
Follows up on the discussion in #4  . A first draft of a PmX-specific glossary for LLM-based agentic workflows. Meant as a concrete starting point for discussion, not a finished proposal; edits, restructuring, or a different approach entirely are all welcome. Mainly checking early whether this matches what you had in mind, @AriAnthony. 

## What's in this PR

- **Quarto site**: `_quarto.yml` and `index.qmd` under `docs/`. The site is configured at the `docs/` level so it could later host other community resources beyond the glossary. This was my interpretation of your comment in #4; happy to adjust if you'd prefer a different setup for the GitHub Pages integration or if you had something else in mind.
> I can setup the GitHub Pages once we have something to point it to, though I'd fold it into the existing repo build (Quarto rendering from docs/) rather than building separate infrastructure.
- **Glossary structure** under `docs/learning/glossary/`:
  - `template.qmd` defining a common entry structure (one-sentence summary, definition, "In pharmacometrics" section with examples, related terms, further reading)
  - Placeholder entries (template copies with lorem ipsum) for **Agent**, **Harness**, and **Tools**
  - One fully worked entry, **Model Context Protocol (MCP)**, as an example of what a complete entry could look like (incl. two SVG diagrams generated by Claude). 

## Preview

Render locally with `quarto render docs/` or `quarto preview docs/`. I gitignored _site/, not sure if that is common practice or not.

This is the template:

<img width="1348" height="1176" alt="image" src="https://github.com/user-attachments/assets/8c60ab2a-72d8-47ce-9e5f-e654e3c7d69a" />


And the MCP example:

<img width="2465" height="1252" alt="image" src="https://github.com/user-attachments/assets/156bc7b6-c082-47b8-80b3-26a9dcbee3b7" />

<img width="2465" height="1240" alt="image" src="https://github.com/user-attachments/assets/48ffe6a2-ddd6-4ef1-8b46-9de5ccb05f61" />


## Open questions

1. **Target audience and depth.** While writing the MCP entry I realized this is a core design question: it's not quite obvious what background readers will have, so it's unclear how deep entries should go. I went with a general definition paired with the role in PMx plus concrete examples; but the line between "glossary entry" and "blog post" is rather narrow. Worth discussing in the bigger round in the next meeting: should this be brief definitions only, or more explanatory entries like the MCP one?
2. **Contribution workflow.** If we proceed with something like this, we should probably add short documentation on how to contribute an entry, so the glossary can become a living document that people extend themselves rather than depending on a few maintainers. Not sure if everyone is familiar with quarto.