### PR TITLE
Fix incorrect task-library dependencies

### DIFF
--- a/tools/modus/ai_docs/task_library.json
+++ b/tools/modus/ai_docs/task_library.json
@@ -96,7 +96,7 @@
       "If a result cannot be reconciled, write ESCALATE.txt instead of signing off",
       "The sign-off must state what was checked and what was not"
     ],
-    "depends_on": ["data_qc", "structural_model", "covariate_analysis"],
+    "depends_on": ["data_qc", "structural_model", "covariate_analysis", "pkpd_model", "dose_recommendation"],
     "passes": false
   },
   {
@@ -124,7 +124,7 @@
       "Requires a measured pharmacodynamic or biomarker endpoint linked to exposure",
       "Fix individual PK parameters from the final PK model and estimate the PD parameters"
     ],
-    "depends_on": ["study_context"],
+    "depends_on": ["study_context", "structural_model"],
     "passes": false
   },
   {
@@ -137,7 +137,7 @@
       "Requires a defined PK/PD or exposure-response target to simulate against",
       "Simulate a virtual population matching the study covariate distributions and evaluate candidate doses"
     ],
-    "depends_on": ["structural_model"],
+    "depends_on": ["pkpd_model", "covariate_analysis"],
     "passes": false
   }
 ]


### PR DESCRIPTION
## Audit finding

The Modus task library (`tools/modus/ai_docs/task_library.json`) had three dependency errors, all on the PK/PD + simulation branch. The graph generator (`gen_task_graph.py`) just renders whatever's in the JSON, so the fixes are entirely in the data.

### Before → After

| task | before | after |
|---|---|---|
| `pkpd_model` | `["study_context"]` | `["study_context", "structural_model"]` |
| `dose_recommendation` | `["structural_model"]` | `["pkpd_model", "covariate_analysis"]` |
| `review` | `[data_qc, structural_model, covariate_analysis]` | `+ pkpd_model, dose_recommendation` |

### Why

1. **`pkpd_model` contradicted its own rule.** Its rule is *"Fix individual PK parameters from the final PK model,"* yet it depended only on `study_context` — it could start before any PK model existed. Now depends on `structural_model`.
2. **`dose_recommendation` had incomplete inputs.** Its rules require a defined PK/PD / exposure-response target (produced by `pkpd_model`) and a covariate-aware virtual population (from `covariate_analysis`); it only depended on `structural_model`. Repointed to both.
3. **`pkpd_model` and `dose_recommendation` were orphan leaves.** Nothing consumed them, so their results reached neither `review` nor `submission` — never independently verified, never assembled into the submission. Added both to `review`'s `depends_on` so whichever survives `scope` pruning is verified and reported.

### Validation

- JSON is well-formed; graph is still a valid DAG (no cycles).
- `submission` is now the sole leaf node; no orphan branches remain.
- Regenerated `task_library_graph.html` renders cleanly (9 tasks, 8 layers, 15 edges, 3 crossings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)