### PR TITLE
Link back to the repo from the site navbar

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -13,6 +13,14 @@ website:
         href: learning/glossary/agent.qmd
       - text: "Leaderboard"
         href: leaderboard.qmd
+    right:
+      # Labelled rather than icon-only. Much of this audience arrives from a talk
+      # or a LinkedIn post to read the glossary, not from GitHub, and a bare
+      # octocat is easy to miss if you are not already looking for one.
+      - text: "Repo"
+        icon: github
+        href: https://github.com/AIML-SIG/Agentic-workflows
+        aria-label: "Agentic Workflows on GitHub"
 
   sidebar:
     - id: glossary


### PR DESCRIPTION
The site navbar offered **Glossary** and **Leaderboard** and no way back to the source.

Someone arriving from the talk, the blog post or LinkedIn lands on the leaderboard and hits a dead end — which is backwards, since the repo is what the whole funnel points at and where the First Run milestone lives.

Adds a right-aligned **Repo** item to the navbar.

Labelled rather than icon-only on purpose: much of this audience arrives to read a glossary explaining what an agent *is*, and a bare octocat is easy to miss if you aren't already looking for one. The GitHub icon is kept alongside the label for recognisability, plus an `aria-label`.

Deploys automatically on merge — `docs/**` is a trigger path for `site.yml`.

**Not verified locally:** Quarto project render silently no-ops in the environment this was written in (single-file render works). The config parses and `navbar.right` is standard Quarto, and the CI render is now proven working, so this verifies on deploy.