### PR TITLE
Drop --no-individual-runs now that the run links resolve

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -57,18 +57,16 @@ jobs:
       # costs seconds, and the render step needs the file to exist regardless of
       # what triggered the run.
       #
-      # Both flags are required and have each regressed once when run by hand.
-      # Encoding them here is the actual fix -- nobody types them again.
-      #
-      # --no-individual-runs can be dropped now that results/ lives on main and
-      # the per-run links resolve (see #21). Left on so the board matches what is
-      # published today; flipping it is a one-line change.
+      # --exclude-dataset has regressed once when run by hand; encoding it here is
+      # the fix. --no-individual-runs was dropped once results/ landed on main:
+      # it existed only because the per-run drill-down links pointed at folders
+      # that did not exist there yet and would have 404'd. They resolve now, so
+      # the board carries its individual-runs table (#21).
       - name: Generate docs/leaderboard.qmd
         working-directory: tools/pharmbench
         run: |
           python3 generate_leaderboard.py \
-            --exclude-dataset pmb-mab-pkpd-v0 \
-            --no-individual-runs
+            --exclude-dataset pmb-mab-pkpd-v0
 
       - uses: quarto-dev/quarto-actions/setup@v2
 


### PR DESCRIPTION
The flag existed for exactly one reason: the per-run drill-down links point at `tools/pharmbench/results/` on `main`, and until #24 that directory was empty there — so every link would have 404'd.

#24 put the 24 runs on `main`, which is the condition #21 set for dropping it.

**Verified rather than assumed.** Generated the board without the flag and requested the resulting links against the live repo: 22 run entries, all returning 200, both the `tree` links and the `slide.html` blob links.

The board now carries its individual-runs table, so a reader can go from a score straight to that run's scorecard, submission and rendered slide.

`--exclude-dataset` stays — pkpd runs are still excluded, and that flag has regressed once when typed by hand, which is why it lives in the workflow rather than in someone's shell history.

Closes the last residual on #21. Deploys on merge; `.github/workflows/site.yml` is a trigger path.