### PR TITLE
Fix the leaderboard docs to match how it actually works

### DIFF
--- a/tools/AGENTS.md
+++ b/tools/AGENTS.md
@@ -76,7 +76,10 @@ Verify, and install what's missing, before running anything:
    is the fitting engine the workflow tasks use at run time. Install:
    `Rscript -e 'install.packages(c("mrgsolve","yaml","nlmixr2"))'`. Confirm
    with `Rscript -e 'library(nlmixr2)'`.
-3. **Python 3 + pyyaml** — only for the optional `pharmbench/visualize_results.py`.
+3. **Python 3 + pyyaml** — for `pharmbench/generate_leaderboard.py` (renders
+   `docs/leaderboard.qmd` and the per-run drill-down slides; CI runs it on every push
+   to `main`, so you only need it to preview the board locally) and for the optional
+   `pharmbench/visualize_results.py`.
 
 ## Then run, in this order
 

--- a/tools/pharmbench/README.md
+++ b/tools/pharmbench/README.md
@@ -181,18 +181,28 @@ harness streams a different event shape (`claude`'s `stream-json` vs. `pi`'s
 own format, etc.), so parsing them for drill-down would mean a bespoke
 extractor per harness rather than one general tool.
 
-Then regenerate the leaderboard, which also (re)renders every run's
-drill-down slide (score breakdown + trap ledger, derived from the scorecard,
-submission, and the scenario's `truth.yaml` — no wall-clock/cost timeline,
-since that needs the log this deliberately doesn't keep):
+**Commit only the new `results/<slug>/` folder.** `--record` is opt-in specifically
+so ad hoc scoring (the smoke test above) doesn't silently create a leaderboard entry.
+
+**Do not commit `docs/leaderboard.qmd`** — it is generated, and it is not tracked in
+git. `.github/workflows/site.yml` regenerates it from the whole of `results/` on every
+push to `main` and publishes the site, so your run reaches the board on merge without
+you doing anything. This is also why contributor PRs never collide on it: a generated
+file committed by many people at once means later merges silently drop earlier entries.
+
+You only need to run the generator yourself to preview the board locally, or to work
+out why a run isn't appearing. It also (re)renders every run's drill-down slide (score
+breakdown + trap ledger, derived from the scorecard, submission and the scenario's
+`truth.yaml` — no wall-clock/cost timeline, since that needs the log this deliberately
+doesn't keep):
 
 ```sh
-python3 generate_leaderboard.py
+python3 generate_leaderboard.py --exclude-dataset pmb-mab-pkpd-v0
 ```
 
-Commit the new `results/<slug>/` folder together with the regenerated
-`docs/leaderboard.qmd`. `--record` is opt-in specifically so ad hoc scoring
-(the smoke test above) doesn't silently create a leaderboard entry.
+`--exclude-dataset` matters: without it the board picks up `pmb-mab-pkpd-v0` runs,
+which are excluded from the published leaderboard. The workflow always passes it, so
+pass it locally too or your preview won't match the site. Needs `pyyaml`.
 
 ## Scoring
 


### PR DESCRIPTION
`tools/pharmbench/README.md` was the last place still telling contributors to do the thing #18 forbids. Its only mention of the generator said:

> Commit the new `results/<slug>/` folder together with the regenerated `docs/leaderboard.qmd`

That file is generated, is **no longer tracked in git**, and is regenerated centrally by `site.yml` on every push to `main`. Someone following the README would try to commit a path git ignores — and if it *were* tracked, concurrent PRs would collide on it and later merges would silently drop earlier entries. Same class of contradiction as the one fixed on #19, but in the doc a contributor is most likely to actually read.

**The command was wrong too.** It showed a bare `python3 generate_leaderboard.py` with no `--exclude-dataset`, so a local run picks up `pmb-mab-pkpd-v0` entries the published board excludes and the preview doesn't match the site.

Now says the generator is for previewing locally or debugging a missing run, that CI owns the board, and shows the command with the flag. **Verified by running it exactly as documented** — 22 runs, and git correctly ignores the output.

Also `tools/AGENTS.md` called `pyyaml` a dependency "only for the optional `visualize_results.py`". It's also what `generate_leaderboard.py` needs.

Docs only — no code or workflow changes.