### PR TITLE
Add front-and-center First Run pointer to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A working subgroup of the [ISoP AI/ML SIG](https://www.isop.org/special-interest-groups/aiml-sig), bringing pharmacometricians together around AI agents and agentic workflows. Join the conversation in [Discussions](../../discussions).
 
+**New here?** The fastest way in is the [First Run milestone](../../milestone/1), the on-ramp into the biweekly evaluation subgroup. The bar is effort, not a passing score: run it, tell us what happened, and you're in. Questions and reports go in the [First Run discussion](../../discussions/28).
+
 ## Mission
 
 To bring together a community of pharmacometricians to discover, evaluate, and produce agentic workflows, codifying their collective expertise into shared, verifiable standards of practice that grow with the field.


### PR DESCRIPTION
Someone landing on the repo directly, not via the blog or the WG email, had no path into the subgroup. This adds one paragraph above `## Mission` pointing at the First Run milestone and the Q&A discussion (#28).

The existing First Run mention under `## The site` stays. That one is about adding a leaderboard row. This one is the general entry point.

Both relative links resolve: `../../milestone/1` and `../../discussions/28` return 200.
