### PR TITLE
Add a self-promotion rule to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,12 @@ Use public or synthetic data only. [nlmixr2lib](https://github.com/nlmixr2/nlmix
 
 Write tasks and workflows other people can run. Document them well enough that someone new to the topic can follow along. Include public or synthetic examples so others can reproduce your results.
 
+## Linking your own work
+
+Fine, and often the point. Say what it does, why it belongs in the thread you're posting in, and that it's yours.
+
+What gets hidden: a comment whose substance is the pitch, an account whose only activity here is a product link, or a commercial product introduced as a community contribution. If you want your tool taken seriously, run it through [First Run](../../milestone/1) and post what happened. That lands better than a link.
+
 ## Questions
 
 Ask in [Discussions](../../discussions) or raise them at a monthly meeting.


### PR DESCRIPTION
Two comments on Discussion #6 (Evaluation and trust) were relevant-sounding writeups that ended in a link to the author's own product. One is from an account created weeks ago whose bio is the product. There was nothing in `CONTRIBUTING.md` to point at when hiding them, which makes moderation look arbitrary.

Adds a short **Linking your own work** section between *What helps* and *Questions*. It permits the normal case, someone links a tool they built and it's on topic, and names the three shapes that get hidden. It also points people at First Run, since a benchmark result is the thing that actually earns a tool attention here.

No other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDWLWq5oEQoLCH9UzfXA7k