### PR TITLE
Record PMbench baseline and Modus runs

### DIFF
--- a/tools/pharmbench/results/pmb-mab-poppk-v0__baseline__codex__gpt-5-6-terra__20260805T000000Z__8400a3/scorecard.yaml
+++ b/tools/pharmbench/results/pmb-mab-poppk-v0__baseline__codex__gpt-5-6-terra__20260805T000000Z__8400a3/scorecard.yaml
@@ -1,0 +1,56 @@
+dataset: pmb-mab-poppk-v0
+provenance:
+  tool: baseline
+  tool_sha: unknown
+  model: gpt-5.6-terra
+  run_utc: '2026-08-05T00:00:00Z'
+  analysis_steps:
+  - dataset_qc
+  - censored_data_diagnostic
+  - individual_log_pk_fits
+  - structural_model_comparison
+  - covariate_screening
+  - population_parameter_estimation
+  pharmbench_sha: 43c3e8087a5a
+  harness: codex
+  agent_cmd: codex exec --json --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox
+    --model gpt-5.6-terra
+items:
+  structural_ncmt:
+    score: 1.0
+    scorer: categorical
+    answered: yes
+    pmx_area: structural
+    weight: 1
+  disposition_params:
+    score: 0.8586
+    scorer: map
+    answered: yes
+    pmx_area: estimation
+    weight: 1
+  error_model:
+    score: 1.0
+    scorer: map
+    answered: yes
+    pmx_area: estimation
+    weight: 1
+  cov_effects:
+    score: 1.0
+    scorer: map_nested
+    answered: yes
+    pmx_area: covariate-analysis
+    weight: 1
+  outlier_records:
+    score: 0.8571
+    scorer: set
+    answered: yes
+    pmx_area: data-quality
+    weight: 1
+by_pmx_area:
+  structural: 1.0
+  estimation: 0.9293
+  covariate-analysis: 1.0
+  data-quality: 0.8571
+overall: 0.9431
+unanswered_items: none
+traps_fallen_for: none detected

--- a/tools/pharmbench/results/pmb-mab-poppk-v0__baseline__codex__gpt-5-6-terra__20260805T000000Z__8400a3/submission.yaml
+++ b/tools/pharmbench/results/pmb-mab-poppk-v0__baseline__codex__gpt-5-6-terra__20260805T000000Z__8400a3/submission.yaml
@@ -1,0 +1,32 @@
+provenance:
+  tool: baseline
+  tool_sha: ""
+  model: ""
+  run_utc: "2026-08-05T00:00:00Z"
+  analysis_steps:
+    - dataset_qc
+    - censored_data_diagnostic
+    - individual_log_pk_fits
+    - structural_model_comparison
+    - covariate_screening
+    - population_parameter_estimation
+
+answers:
+  structural_ncmt: 2
+  disposition_params:
+    CL: 0.20
+    Vc: 3.00
+    Q: 0.50
+    Vp: 3.00
+  error_model:
+    prop: 0.15
+  cov_effects:
+    CL:
+      WT: 0.75
+    Vc:
+      WT: 1.0
+  outlier_records:
+    - "62"
+    - "692"
+    - "1322"
+    - "1323"

--- a/tools/pharmbench/results/pmb-mab-poppk-v0__modus__codex__gpt-5-6-terra__20260805T092646Z__74a6cc/scorecard.yaml
+++ b/tools/pharmbench/results/pmb-mab-poppk-v0__modus__codex__gpt-5-6-terra__20260805T092646Z__74a6cc/scorecard.yaml
@@ -1,0 +1,57 @@
+dataset: pmb-mab-poppk-v0
+provenance:
+  tool: modus
+  tool_sha: unknown
+  model: gpt-5.6-terra
+  run_utc: '2026-08-05T09:26:46Z'
+  analysis_steps:
+  - scope
+  - study_context
+  - data_qc
+  - structural_model
+  - covariate_analysis
+  - review
+  - submission
+  pharmbench_sha: 43c3e8087a5a
+  harness: codex
+  agent_cmd: codex exec --json --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox
+    --model gpt-5.6-terra
+items:
+  structural_ncmt:
+    score: 1.0
+    scorer: categorical
+    answered: yes
+    pmx_area: structural
+    weight: 1
+  disposition_params:
+    score: 0.84
+    scorer: map
+    answered: yes
+    pmx_area: estimation
+    weight: 1
+  error_model:
+    score: 0.0
+    scorer: map
+    answered: yes
+    pmx_area: estimation
+    weight: 1
+  cov_effects:
+    score: 0.7913
+    scorer: map_nested
+    answered: yes
+    pmx_area: covariate-analysis
+    weight: 1
+  outlier_records:
+    score: 1.0
+    scorer: set
+    answered: yes
+    pmx_area: data-quality
+    weight: 1
+by_pmx_area:
+  structural: 1.0
+  estimation: 0.42
+  covariate-analysis: 0.7913
+  data-quality: 1.0
+overall: 0.7263
+unanswered_items: none
+traps_fallen_for: none detected

--- a/tools/pharmbench/results/pmb-mab-poppk-v0__modus__codex__gpt-5-6-terra__20260805T092646Z__74a6cc/submission.yaml
+++ b/tools/pharmbench/results/pmb-mab-poppk-v0__modus__codex__gpt-5-6-terra__20260805T092646Z__74a6cc/submission.yaml
@@ -1,0 +1,32 @@
+provenance:
+  tool: modus
+  tool_sha: "unknown"
+  model: gpt-5.6-terra
+  run_utc: "2026-08-05T09:26:46Z"
+  analysis_steps:
+    - scope
+    - study_context
+    - data_qc
+    - structural_model
+    - covariate_analysis
+    - review
+    - submission
+
+answers:
+  structural_ncmt: 2
+  disposition_params:
+    CL: 0.2076179562277894
+    V: 3.1543653086997905
+    Q: 0.6128899616793901
+    VP: 3.0890802415164345
+  error_model:
+    log_residual_sd: 0.11492395100024592
+  cov_effects:
+    CL:
+      WT: 0.819
+    V:
+      WT: 1.010
+  outlier_records:
+    - "62"
+    - "692"
+    - "1322"


### PR DESCRIPTION
## PMbench First Run

Recorded two blinded PMbench runs with the same configuration:

- Harness/model: `codex` / `gpt-5.6-terra`
- Baseline: **0.9431** — no traps detected
- Modus: **0.7263** — no traps detected

Modus selected the correct structural model and identified the exact outliers, but lost score because it reported log-scale residual error under `log_residual_sd` rather than the benchmark’s proportional-error `prop` field.

Only the two recorded result folders are included. The leaderboard and per-run slide are generated by CI after merge.