### PR TITLE
Put the sign-up CTA at the top of the README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Archived pmbench run workspaces copied out of the ephemeral devcontainer /tmp.
+# Full project dirs incl. raw logs -- large (GBs), local-only, never committed.
+run_archive/
+
+# Local-only live-demo explorer (run dirs copied from devcontainer /tmp; see demo/DEMO.md)
+demo/
+
+# Claude Code local config + vendored skills (node_modules etc.) — local-only.
+.claude/
+
+# Scratch working dirs (unpacked decks, render output, staging) — regenerable.
+.scratch/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # Agentic Pharmacometrics
 
-A working subgroup of the [ISoP AI/ML SIG](https://www.isop.org/special-interest-groups/aiml-sig), bringing pharmacometricians together around AI agents and agentic workflows. Join the conversation in [Discussions](../../discussions).
+A working subgroup of the [ISoP AI/ML SIG](https://www.isop.org/special-interest-groups/aiml-sig), bringing pharmacometricians together around AI agents and agentic workflows.
+
+## Join us
+
+Two ways in, both take under a minute. Membership is free and open to anyone.
+
+- **[Sign up with the form](https://forms.gle/BX4Ff7fTdhB3jucw9).** Quickest way in.
+- **[Subscribe by email](mailto:agentic-workflows+subscribe@googlegroups.com).** Send a blank message; works behind corporate firewalls.
+
+Once you are in, the conversation happens in [Discussions](../../discussions).
 
 **New here?** Start with the [First Run milestone](../../milestone/1). Run it, tell us what happened, and you're in the biweekly evaluation subgroup. You don't need a passing score. Reporting what blocked you counts. Questions and results go in the [First Run discussion](../../discussions/28).
 
@@ -24,13 +33,6 @@ The group publishes at **[aiml-sig.github.io/Agentic-workflows](https://aiml-sig
 
 - **[Glossary](https://aiml-sig.github.io/Agentic-workflows/learning/glossary/agent.html).** Plain-language definitions of the terms this field uses loosely: agent, harness, tools, MCP. Start here if the vocabulary is the barrier.
 - **[Leaderboard](https://aiml-sig.github.io/Agentic-workflows/leaderboard.html).** PMbench scores for every recorded run: which workflow, on which model and harness, at what score and cost. To add a row of your own, work through the [First Run milestone](../../milestone/1).
-
-
-## Join us
-
-- [Subscribe by email](mailto:agentic-workflows+subscribe@googlegroups.com)
-  (works behind corporate firewalls)
-- Prefer a form? [Sign up here](https://forms.gle/BX4Ff7fTdhB3jucw9)
 
 ## License
 


### PR DESCRIPTION
Two commits.

**Put the sign-up CTA at the top of the README.** The two ways to join sat at the bottom of the README, below the mission, objectives and site sections. A reader arriving from a talk or a LinkedIn post had to scroll past everything to find them. The block now sits directly under the one-line description, leads with the form as the low-friction path, and spells out the blank-message step for the mailing list. Discussions follows the CTA as the next step rather than being buried in the opening sentence.

Bullets use the bold-label-period pattern from fa9b5e0 rather than em dashes. Both link targets are unchanged.

**Carry the root .gitignore over to main.** `main` had no root `.gitignore`, so a clone of `main` that runs Claude Code or archives a PMbench run surfaces over a thousand untracked local-only files, including a vendored `node_modules` and a ~9 MB shared library. That makes `git add -A` actively dangerous on this branch. Taken verbatim from `dev` so the two branches stay in sync rather than drifting again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WEunWpbuPMGoZpHcZxvyAs