### PR TITLE
PMbench baseline and modus run marianklose

### DIFF
--- a/tools/pharmbench/results/pmb-mab-poppk-v0__baseline__claude__claude-sonnet-5__20260903T165316Z__2609d4/scorecard.yaml
+++ b/tools/pharmbench/results/pmb-mab-poppk-v0__baseline__claude__claude-sonnet-5__20260903T165316Z__2609d4/scorecard.yaml
@@ -1,0 +1,70 @@
+dataset: pmb-mab-poppk-v0
+provenance:
+  tool: baseline
+  tool_sha: ff883ee61f46
+  model: claude-sonnet-5
+  run_utc: '2026-09-03T16:53:16Z'
+  analysis_steps:
+  - 'exploratory data review: dose/covariate ranges, BLQ patterns, N=120 subjects,
+    3 dose cohorts'
+  - 'QC scan: per-subject log-linear interpolation residuals flagged 3 gross outlier
+    records (ROWID 62, 692, 1322), each a >8-fold spike at DAY 7 inconsistent with
+    neighboring visits and with the population; excluded from fitting'
+  - 'structural model selection via nlmixr2: fit 1-compartment vs 2-compartment IV
+    infusion models (SAEM); 2-compartment strongly favored (AIC 11599 vs 14188) and
+    gave physiologically reasonable IIV, so selected as final structural model'
+  - 'BLQ handling: records below LLOQ (0.1 mg/L) modeled as left-censored (M3-type
+    likelihood via CENS/LIMIT) rather than discarded or set to LLOQ/2'
+  - 'covariate screening: correlated empirical Bayes etas (CL, V) against WT, ALB,
+    CRCL (log-log) on a well-converged, low-shrinkage base 2-compartment fit'
+  - 'covariate model building via nested FOCEI fits and likelihood ratio tests: WT
+    supported as a power (allometric) covariate on both CL (exponent ~0.79, LRT p<0.0001)
+    and V (exponent ~1.04, LRT p<0.0001); ALB''s univariate association with CL eta
+    disappeared after adjusting for WT (confounded via WT-ALB correlation, r=0.40)
+    and was not retained; CRCL showed no association with either parameter, consistent
+    with the mAb not being renally eliminated'
+  - 'final model diagnostics: CWRES mean~0, SD~0.94, <0.15% beyond |3|; eta shrinkage
+    1.2% (CL) and 9.6% (V), supporting reliable individual estimates'
+  pharmbench_sha: ff883ee61f46
+  harness: claude
+  agent_cmd: claude -p --model claude-sonnet-5 --verbose --output-format stream-json
+    --dangerously-skip-permissions
+items:
+  structural_ncmt:
+    score: 1.0
+    scorer: categorical
+    answered: yes
+    pmx_area: structural
+    weight: 1
+  disposition_params:
+    score: 0.9456
+    scorer: map
+    answered: yes
+    pmx_area: estimation
+    weight: 1
+  error_model:
+    score: 0.5
+    scorer: map
+    answered: yes
+    pmx_area: estimation
+    weight: 1
+  cov_effects:
+    score: 0.8001
+    scorer: map_nested
+    answered: yes
+    pmx_area: covariate-analysis
+    weight: 1
+  outlier_records:
+    score: 1.0
+    scorer: set
+    answered: yes
+    pmx_area: data-quality
+    weight: 1
+by_pmx_area:
+  structural: 1.0
+  estimation: 0.7228
+  covariate-analysis: 0.8001
+  data-quality: 1.0
+overall: 0.8491
+unanswered_items: none
+traps_fallen_for: none detected

--- a/tools/pharmbench/results/pmb-mab-poppk-v0__baseline__claude__claude-sonnet-5__20260903T165316Z__2609d4/submission.yaml
+++ b/tools/pharmbench/results/pmb-mab-poppk-v0__baseline__claude__claude-sonnet-5__20260903T165316Z__2609d4/submission.yaml
@@ -1,0 +1,36 @@
+# submission.yaml — the machine-readable answer extraction for PMB-MAB-01.
+
+provenance:
+  tool: baseline
+  tool_sha: ""
+  model: "claude-sonnet-5"
+  run_utc: "2026-09-03T16:53:16Z"
+  analysis_steps:
+    - "exploratory data review: dose/covariate ranges, BLQ patterns, N=120 subjects, 3 dose cohorts"
+    - "QC scan: per-subject log-linear interpolation residuals flagged 3 gross outlier records (ROWID 62, 692, 1322), each a >8-fold spike at DAY 7 inconsistent with neighboring visits and with the population; excluded from fitting"
+    - "structural model selection via nlmixr2: fit 1-compartment vs 2-compartment IV infusion models (SAEM); 2-compartment strongly favored (AIC 11599 vs 14188) and gave physiologically reasonable IIV, so selected as final structural model"
+    - "BLQ handling: records below LLOQ (0.1 mg/L) modeled as left-censored (M3-type likelihood via CENS/LIMIT) rather than discarded or set to LLOQ/2"
+    - "covariate screening: correlated empirical Bayes etas (CL, V) against WT, ALB, CRCL (log-log) on a well-converged, low-shrinkage base 2-compartment fit"
+    - "covariate model building via nested FOCEI fits and likelihood ratio tests: WT supported as a power (allometric) covariate on both CL (exponent ~0.79, LRT p<0.0001) and V (exponent ~1.04, LRT p<0.0001); ALB's univariate association with CL eta disappeared after adjusting for WT (confounded via WT-ALB correlation, r=0.40) and was not retained; CRCL showed no association with either parameter, consistent with the mAb not being renally eliminated"
+    - "final model diagnostics: CWRES mean~0, SD~0.94, <0.15% beyond |3|; eta shrinkage 1.2% (CL) and 9.6% (V), supporting reliable individual estimates"
+
+answers:
+  structural_ncmt: 2
+
+  disposition_params:
+    CL: 0.196
+    V: 2.98
+    Q: 0.605
+    VP: 2.97
+
+  error_model:
+    prop: 0.150
+    add: 0.0116
+
+  cov_effects:
+    CL:
+      WT: 0.787
+    V:
+      WT: 1.04
+
+  outlier_records: ["62", "692", "1322"]

--- a/tools/pharmbench/results/pmb-mab-poppk-v0__modus__claude__claude-sonnet-5__20260903T184513Z__5c59fd/scorecard.yaml
+++ b/tools/pharmbench/results/pmb-mab-poppk-v0__modus__claude__claude-sonnet-5__20260903T184513Z__5c59fd/scorecard.yaml
@@ -1,0 +1,56 @@
+dataset: pmb-mab-poppk-v0
+provenance:
+  tool: modus
+  tool_sha: 56d16563b445
+  model: claude-sonnet-5
+  run_utc: '2026-09-03T18:45:13Z'
+  analysis_steps:
+  - scope
+  - study_context
+  - data_qc
+  - structural_model
+  - covariate_analysis
+  - review
+  pharmbench_sha: 56d16563b445
+  harness: claude
+  agent_cmd: claude -p --model claude-sonnet-5 --verbose --output-format stream-json
+    --dangerously-skip-permissions
+items:
+  structural_ncmt:
+    score: 1.0
+    scorer: categorical
+    answered: yes
+    pmx_area: structural
+    weight: 1
+  disposition_params:
+    score: 0.9464
+    scorer: map
+    answered: yes
+    pmx_area: estimation
+    weight: 1
+  error_model:
+    score: 0.4871
+    scorer: map
+    answered: yes
+    pmx_area: estimation
+    weight: 1
+  cov_effects:
+    score: 0.7419
+    scorer: map_nested
+    answered: yes
+    pmx_area: covariate-analysis
+    weight: 1
+  outlier_records:
+    score: 1.0
+    scorer: set
+    answered: yes
+    pmx_area: data-quality
+    weight: 1
+by_pmx_area:
+  structural: 1.0
+  estimation: 0.7168
+  covariate-analysis: 0.7419
+  data-quality: 1.0
+overall: 0.8351
+unanswered_items: none
+traps_fallen_for: none detected

--- a/tools/pharmbench/results/pmb-mab-poppk-v0__modus__claude__claude-sonnet-5__20260903T184513Z__5c59fd/submission.yaml
+++ b/tools/pharmbench/results/pmb-mab-poppk-v0__modus__claude__claude-sonnet-5__20260903T184513Z__5c59fd/submission.yaml
@@ -1,0 +1,43 @@
+# submission.yaml — the machine-readable answer extraction for PMB-MAB-01.
+
+provenance:
+  tool: modus
+  tool_sha: "56d16563b445f86a29990193e61eef878ed068c4"
+  model: "claude-sonnet-5"
+  run_utc: "2026-09-03T18:45:13Z"
+  analysis_steps:
+    - scope
+    - study_context
+    - data_qc
+    - structural_model
+    - covariate_analysis
+    - review
+
+answers:
+  structural_ncmt: 2
+
+  # Typical (population) disposition-parameter values at the 70 kg reference
+  # weight, from covariate_analysis_final_params.csv (final model: 2-compartment,
+  # WT on CL and V).
+  disposition_params:
+    CL: 0.195522248802137
+    V: 2.97890594479337
+    Vp: 2.9736961838271
+    Q: 0.60380541592913
+
+  # Residual-error terms of the final model.
+  error_model:
+    add: 0.0120327550215327
+    prop: 0.149018219334315
+
+  # Covariate effects the analysis defends (power exponents on (WT/70)).
+  cov_effects:
+    CL:
+      WT: 0.830329833457148
+    V:
+      WT: 1.02142388063459
+
+  outlier_records:
+    - "62"
+    - "692"
+    - "1322"


### PR DESCRIPTION
Adds my PMbench runs using Claude Code via Claude Sonnet 5:

* **Baseline:** overall score `0.8491`
* **Modus:** overall score `0.8351`
* No benchmark traps detected in either run.

Both runs used the same model and harness for comparison.

This PR only adds the recorded `results/<slug>/` outputs as requested in #33.
